### PR TITLE
Add ability to only block for specific jobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ There are currently a couple of prerequisites for using the `do-exclusively` scr
 
 ## Usage
 
-`do-exclusively --branch <somebranch> --tag <sometag> echo "whatever commands I want"`
+`do-exclusively --branch <somebranch> --tag <sometag> --job <somejob> echo "whatever commands I want"`
 The branch and tag arguments are both optional and limit the scope of the command and its lock to a given branch
 name or builds whose commit message contains a certain commit message. If neither option is used,
 the wrapped command will run on every build of the project and will wait for any other builds of the
@@ -28,3 +28,8 @@ other builds tagged [smoketest] finish before this action begins.
 
 Only run on builds on the `staging` branch, and wait for all other `staging` branch builds
 to finish before running.
+
+`do-exclusively --job terraform-plan --job terraform-apply terraform plan > out.plan`
+
+Only wait for jobs with the names `terraform-plan` and `terraform-apply` to
+finish before running.

--- a/do-exclusively
+++ b/do-exclusively
@@ -1,10 +1,28 @@
 #!/usr/bin/env bash
 
+set -e
+set -u
+set -o pipefail
 
-# sets $branch, $tag, $rest
+branch=""
+tag=""
+declare -a job=()
+declare -a rest=()
+
+# Join an array by a string
+function join_by {
+    local d=$1
+    shift
+    echo -n "$1"
+    shift
+    printf "%s" "${@/#/$d}"
+}
+
+# sets $branch, $tag, $job, $rest
 parse_args() {
     while [[ $# -gt 0 ]]; do
         case $1 in
+            -j|--job) job=( "${job[@]}" "$2" ) ;;
             -b|--branch) branch="$2" ;;
             -t|--tag) tag="$2" ;;
             *) break ;;
@@ -42,42 +60,40 @@ make_jq_prog() {
         jq_filters+=" and (.subject | contains(\"[$tag]\"))"
     fi
 
+    if [[ ${#job[@]} != 0 ]]; then
+        jq_filters+=" and (.workflows.job_name | test(\"$(join_by "|" "${job[@]}")\")) "
+    fi
+
     jq_prog=".[] | select(.build_num < $CIRCLE_BUILD_NUM and (.status | test(\"running|pending|queued\")) $jq_filters) | .build_num"
+    echo $jq_prog
 }
 
 
-if [[ "$0" != *bats* ]]; then
-set -e
-set -u
-set -o pipefail
+api_url="https://circleci.com/api/v1/project/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME?circle-token=$CIRCLE_TOKEN&limit=100"
 
-    branch=""
-    tag=""
-    rest=()
-    api_url="https://circleci.com/api/v1/project/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME?circle-token=$CIRCLE_TOKEN&limit=100"
+parse_args "$@"
+commit_message=$(git log -1 --pretty=%B)
+if should_skip; then exit 0; fi
+make_jq_prog
 
-    parse_args "$@"
-    commit_message=$(git log -1 --pretty=%B)
-    if should_skip; then exit 0; fi
-    make_jq_prog
+echo "Checking for running builds..."
 
-    echo "Checking for running builds..."
-
-    while true; do
-        builds=$(curl -s -H "Accept: application/json" "$api_url" | jq "$jq_prog")
-        if [[ $builds ]]; then
-            echo "Waiting on builds:"
-            echo "$builds"
-        else
-            break
-        fi
-        echo "Retrying in 5 seconds..."
-        sleep 5
-    done
-
-    echo "Acquired lock"
-
-    if [[ "${#rest[@]}" -ne 0 ]]; then
-        "${rest[@]}"
+while true; do
+    echo $api_url
+    echo $jq_prog
+    builds=$(curl -s -H "Accept: application/json" "$api_url" | jq "$jq_prog")
+    if [[ $builds ]]; then
+        echo "Waiting on builds:"
+        echo "$builds"
+    else
+        break
     fi
+    echo "Retrying in 5 seconds..."
+    sleep 5
+done
+
+echo "Acquired lock"
+
+if [[ "${#rest[@]}" -ne 0 ]]; then
+    "${rest[@]}"
 fi

--- a/do-exclusively
+++ b/do-exclusively
@@ -65,7 +65,6 @@ make_jq_prog() {
     fi
 
     jq_prog=".[] | select(.build_num < $CIRCLE_BUILD_NUM and (.status | test(\"running|pending|queued\")) $jq_filters) | .build_num"
-    echo $jq_prog
 }
 
 
@@ -79,8 +78,6 @@ make_jq_prog
 echo "Checking for running builds..."
 
 while true; do
-    echo $api_url
-    echo $jq_prog
     builds=$(curl -s -H "Accept: application/json" "$api_url" | jq "$jq_prog")
     if [[ $builds ]]; then
         echo "Waiting on builds:"


### PR DESCRIPTION
It seemed useful to us that we could have multiple instances of `do-exclusively` in our circle config that each waited for a particular other named job. As it happens, it was also useful to be able to wait for any number of named jobs. I've added the `--job` flag which can be specified multiple times. The script will wait only until active builds of those particular jobs finish.